### PR TITLE
fix: Add ft_get_valid_rgb function similar ft_atoi for RGB error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,8 @@ SRC_UTIL				= $(addprefix $(SRC_UTIL_DIR), ft_get_line.c \
 														ft_strtrim_back.c \
 														ft_make_img.c \
 														ft_put_img.c \
-							 							ft_str_to_rgb.c)
+							 							ft_str_to_rgb.c \
+														ft_get_valid_rgb.c)
 
 SRC_PARSE_DIR			= parse/
 SRC_PARSE				= $(addprefix $(SRC_PARSE_DIR), parse.c \

--- a/include/util.h
+++ b/include/util.h
@@ -12,5 +12,6 @@ void	*ft_make_img(void *mlx_ptr, char *xpmFile);
 int		ft_str_to_rgb(char *str);
 char	*ft_strtrim_back(char const *s1, char const *set);
 void	ft_put_img(t_gl *gl, void *img, int x, int y);
+int		ft_get_valid_rgb(char *str);
 
 #endif

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -32,8 +32,6 @@ void	init_minimap_info(t_minimap_info *minimap_info, t_gl *gl)
 {
 	minimap_info->wall = ft_make_img(gl->mlx_ptr, "wall.xpm");
 	minimap_info->space = ft_make_img(gl->mlx_ptr, "space.xpm");
-	minimap_info->pos.x = 0;
-	minimap_info->pos.y = 0;
 }
 
 void	init_state(t_state *state)

--- a/src/parse/valid_map.c
+++ b/src/parse/valid_map.c
@@ -18,7 +18,7 @@ static void	valid_character(t_map_info *map_info, int row, int *player_cnt)
 			if (*player_cnt != 1)
 				throw_error("InvalidMapError : too many player exist");
 		}
-		if (ft_strchr("01 ", line[col]) == 0)
+		else if (ft_strchr("01 ", line[col]) == 0)
 			throw_error("InvalidMapError : invalid character!");
 		col++;
 	}

--- a/src/util/ft_get_valid_rgb.c
+++ b/src/util/ft_get_valid_rgb.c
@@ -1,0 +1,45 @@
+#include "cub3D.h"
+#include "error.h"
+#include "libft.h"
+
+static int	ctoi(char c)
+{
+	int	res;
+
+	res = c - '0';
+	return (res);
+}
+
+static int	detect_flow(int is_minus)
+{
+	if (is_minus == -1)
+		return (0);
+	else
+		return (-1);
+}
+
+int	ft_get_valid_rgb(char *str)
+{
+	long long	res;
+	long long	tmp;
+	int			i;
+
+	i = 0;
+	res = 0;
+	while (str[i] && ft_strchr(WHITESPACE, str[i]))
+		i++;
+	if (str[i] == 0)
+		throw_error("Color Error : RGB value is empty");
+	while (ft_isdigit(str[i]))
+	{
+		tmp = res * 10 + ctoi(str[i++]);
+		if (tmp > 255)
+			throw_error("Color Error : range of color is 0~255");
+		res = tmp;
+	}
+	while (str[i] && ft_strchr(WHITESPACE, str[i]))
+		i++;
+	if (str[i] && !ft_isdigit(str[i]))
+		throw_error("Color Error : R,G,B must be integer not character");
+	return ((int)res);
+}

--- a/src/util/ft_str_to_rgb.c
+++ b/src/util/ft_str_to_rgb.c
@@ -1,16 +1,20 @@
 #include "error.h"
 #include "libft.h"
+#include "parse.h"
+#include "util.h"
 #include <stdio.h>
 
-// static int	get_rgb_num(char *str)
-// {
-// 	int	rgb;
-// throw_error("RGBError : Wrong value of rgb is given.");
-// 	rgb = ft_atoi(str);
-// 	if (rgb == 0 && )
-// 	if (rgb < 0 || rgb > 255)
-// 		return (0);
-// }
+// ',' 가 2개가 아닌 경우 (arr 갯수 체크)
+static void	check_split(char **arr)
+{
+	int	count;
+
+	count = 0;
+	while (arr[count])
+		count++;
+	if (count != 3)
+		throw_error("ColorError : R, G, B is needed");
+}
 
 int	ft_str_to_rgb(char *str)
 {
@@ -19,11 +23,10 @@ int	ft_str_to_rgb(char *str)
 
 	rgb = 0;
 	arr = ft_split(str, ',');
-	rgb += ft_atoi(arr[0]) << 16;
-	rgb += ft_atoi(arr[1]) << 8;
-	rgb += ft_atoi(arr[2]);
-	printf("color: %s\n", str);
-	printf("atoi: %d\n", ft_atoi(str));
+	check_split(arr);
+	rgb += ft_get_valid_rgb(ft_trim_line(arr[0])) << 16;
+	rgb += ft_get_valid_rgb(ft_trim_line(arr[1])) << 8;
+	rgb += ft_get_valid_rgb(ft_trim_line(arr[2]));
 	printf("rgb: %x\n", rgb);
 	return (rgb);
 }


### PR DESCRIPTION
## 개요 
* #11 RGB 에러 처리

## 작업내용 
* RGB 3 값이 들어왔는지 확인 후 에러 처리
* RGB 값이 0~255 범위 내의 값인지 확인 후 에러 처리
* 숫자가 아닌 문자가 포함되어 있는 경우 에러 처리

## 주의사항 